### PR TITLE
Update .gitignore to ignore __pycache__ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .venv/
-__pyca.venv/
+__pycache__/


### PR DESCRIPTION
This pull request updates the .gitignore file to ignore the __pycache__ directory. This directory contains Python bytecode files and is automatically generated by the Python interpreter. Ignoring this directory will prevent it from being tracked by Git and will keep the repository clean.